### PR TITLE
Make field name comparison case-insensitive.

### DIFF
--- a/kicad_bom_seeedstudio.py
+++ b/kicad_bom_seeedstudio.py
@@ -38,9 +38,9 @@ def parse_kicad_xml(input_file):
         opl, mpn = None, None
         if fields is not None:
             for x in fields:
-                if x.attrib['name'] == 'SKU':
+                if x.attrib['name'].upper() == 'SKU':
                     opl = x.text
-                elif x.attrib['name'] == 'MPN':
+                elif x.attrib['name'].upper() == 'MPN':
                     mpn = x.text
         if opl:
             components[name] = opl


### PR DESCRIPTION
This allows "MPN" and "SKU" to be either upper or lower case.  (I had been calling my part numbers "mpn".)